### PR TITLE
Add deletecollection for multi-namespace role

### DIFF
--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -59,6 +59,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The multi-namespace role was missing a deletecollection verb for pod resources. [This verb is present for the single namespace role](https://github.com/ray-project/kuberay-helm/blob/bbde24accbfc842201d7c4c7e6d2e7ebb01bb69f/helm-chart/kuberay-operator/templates/role.yaml#L52-L62).

## Related issue number

https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1719259919331299

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

- Used chart version 1.1.0 locally
- Applied this patch locally and pods were deleted
